### PR TITLE
Make preview app configurable

### DIFF
--- a/doc/asciidoc.txt
+++ b/doc/asciidoc.txt
@@ -88,7 +88,10 @@ render AsciiDoc on the fly, the normal mode {<LocalLeader>of} map can be used
 to open the current file in the external application.
 
     " Preview asciidoc file with `g:asciidoc_preview_app` application
-    nnoremap <buffer> <localleader>of :execute "!open file://" . shellescape(expand('%:p')) . " -a " . g:asciidoc_preview_app<CR>
+    nnoremap <buffer> <LocalLeader>of :execute "!" . g:asciidoc_preview_app . " file://" . shellescape(expand('%:p'))<CR>
+
+    " Set firefox as the default preview app
+    let g:asciidoc_preview_app = 'firefox'
 
 
 *3.2* Follow link
@@ -326,6 +329,7 @@ command! -buffer -nargs=1 AdocInsertTable call asciidoc#base#insert_table(<f-arg
     setlocal spell
     setlocal spelllang=en
     setlocal include=^include::
+    let g:asciidoc_table_autoalign = 0
 
 ==============================================================================
 *7.* Disable defaults					*adoc-disable*

--- a/ftplugin/asciidoc.vim
+++ b/ftplugin/asciidoc.vim
@@ -66,8 +66,9 @@ let g:atx_to_setext = {
 
 " Options ==================================================          {{{
 if -1 < match(g:asciidoc_use_defaults, 'options')
-    let g:asciidoc_browser = "Firefox"
-    let g:asciidoc_preview_app = "Firefox"
+    if !exists('g:asciidoc_preview_app')
+        let g:asciidoc_preview_app = "open"
+    endif
     if !exists('g:asciidoc_debug_level')
         let g:asciidoc_debug_level = 0
     endif
@@ -112,7 +113,7 @@ endif
 " Navigating ===============================================          {{{
 if -1 < match(g:asciidoc_use_defaults, 'navigating')
     " Preview asciidoc file with `g:asciidoc_preview_app` application
-    nnoremap <buffer> <LocalLeader>of :execute "!open file://" . shellescape(expand('%:p')) . " -a " . g:asciidoc_preview_app<CR>
+    nnoremap <buffer> <LocalLeader>of :execute "!" . g:asciidoc_preview_app . " file://" . shellescape(expand('%:p'))<CR>
 
     " Follow link under cursor
     nnoremap <buffer> ,gf :AdocFollowLinkUnderCursor edit<CR>


### PR DESCRIPTION
- `let g:asciidoc_preview_app = "firefox"` to use firefox
- removed unused variable `g:asciidoc_browser`