### PR TITLE
Don't set spelllang in plugin

### DIFF
--- a/ftplugin/asciidoc.vim
+++ b/ftplugin/asciidoc.vim
@@ -77,7 +77,6 @@ if -1 < match(g:asciidoc_use_defaults, 'options')
     setlocal formatoptions=tcqjnro
     let &formatlistpat="^\\s*\\d\\+[\\]:.)}\\t\ ]\\s*"
     setlocal spell
-    setlocal spelllang=en
     setlocal include=^include::
 endif
 " END Options }}}


### PR DESCRIPTION
`spelllang` should only be set by the user, because he knows which language to use. Defaulting to english is bad.